### PR TITLE
Take declaration order into account

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "preact-router-regex",
+  "name": "@dadi/preact-router",
   "amdName": "preactRouterRegex",
-  "version": "2.5.10",
+  "version": "2.6.1",
   "description": "Connect your components up to that address bar.",
   "main": "dist/preact-router-regex.js",
   "jsnext:main": "dist/preact-router-regex.es.js",
@@ -36,12 +36,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mingard/preact-router.git"
+    "url": "https://github.com/dadi/preact-router.git"
   },
   "bugs": {
-    "url": "https://github.com/mingard/preact-router/issues"
+    "url": "https://github.com/dadi/preact-router/issues"
   },
-  "homepage": "https://github.com/mingard/preact-router",
+  "homepage": "https://github.com/dadi/preact-router",
   "peerDependencies": {
     "preact": "*"
   },

--- a/src/util.js
+++ b/src/util.js
@@ -62,7 +62,7 @@ export function pathRankSort(a, b) {
 	if (aAttr.default) return 1;
 	if (bAttr.default) return -1;
 	let diff = rank(aAttr.path) - rank(bAttr.path);
-	return diff || (aAttr.path.length - bAttr.path.length);
+	return diff || -1;
 }
 
 export function segmentize(url) {


### PR DESCRIPTION
Use declaration order as a deciding factor when two routes have the same rank.